### PR TITLE
Use arbitrary strings for JWS token.

### DIFF
--- a/pkg/kubeadm/util/tokens.go
+++ b/pkg/kubeadm/util/tokens.go
@@ -77,15 +77,7 @@ func UseGivenTokenIfValid(s *kubeadmapi.KubeadmConfig) (bool, error) {
 			"length of first part is incorrect [%d (given) != %d (expected) ]",
 			len(givenToken[0]), TokenIDLen))
 	}
-	tokenBytes, err := hex.DecodeString(givenToken[1])
-	if err != nil {
-		return false, fmt.Errorf(invalidErr, err)
-	}
-	if len(tokenBytes) != TokenBytes {
-		return false, fmt.Errorf(invalidErr, fmt.Sprintf(
-			"length of second part is incorrect [%d (given) != %d (expected)]",
-			len(tokenBytes), TokenBytes))
-	}
+	tokenBytes := []byte(givenToken[1])
 	s.Secrets.TokenID = givenToken[0]
 	s.Secrets.BearerToken = givenToken[1]
 	s.Secrets.Token = tokenBytes


### PR DESCRIPTION
Matches a recent commit to discovery API where we use an arbitrary
string, instead of raw bytes that are hex encoded. I have pushed an updated image to dgoodwin/kubediscovery already.

For now, the token itself still is generated as a hex string, however we could just generate any random string there now.

Because we're moving towards supporting arbitrary strings, I removed the length checking on token ID and token.
