### PR TITLE
Add support for external and optionally secured etcd cluster.

### DIFF
--- a/cmd/kubeadm/app/api/types.go
+++ b/cmd/kubeadm/app/api/types.go
@@ -40,6 +40,12 @@ type InitFlags struct {
 	API struct {
 		AdvertiseAddrs   []net.IP
 		ExternalDNSNames []string
+		Etcd             struct {
+			ExternalEndpoints []string
+			ExternalCAFile    string
+			ExternalCertFile  string
+			ExternalKeyFile   string
+		}
 	}
 	Services struct {
 		CIDR      net.IPNet

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -83,6 +83,25 @@ func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 		`(optional) allow to schedule workload to the node`,
 	)
 
+	// TODO (phase1+) @errordeveloper make the flags below not show up in --help but rather on --advanced-help
+
+	cmd.PersistentFlags().StringSliceVar(
+		&s.InitFlags.API.Etcd.ExternalEndpoints, "external-etcd-endpoints", []string{},
+		`(optional) etcd endpoints to use, in case you have an external cluster.`,
+	)
+	cmd.PersistentFlags().StringVar(
+		&s.InitFlags.API.Etcd.ExternalCAFile, "external-etcd-cafile", "",
+		`(optional) etcd certificate authority certificate file."`,
+	)
+	cmd.PersistentFlags().StringVar(
+		&s.InitFlags.API.Etcd.ExternalCertFile, "external-etcd-certfile", "",
+		`(optional) etcd client certificate file."`,
+	)
+	cmd.PersistentFlags().StringVar(
+		&s.InitFlags.API.Etcd.ExternalKeyFile, "external-etcd-keyfile", "",
+		`(optional) etcd client key file."`,
+	)
+
 	return cmd
 }
 


### PR DESCRIPTION
As per request on last week's meeting, I've added support for the usage of external, optionally secured, etcd cluster.

By default, a local, non-secured etcd instance will be bootstrapped. Below are some examples on how to use the external etcd cluster:
#### Local (right now, no TLS or client authentication enabled)

```
kubeadm init
```
#### External, two nodes, no TLS

```
kubeadm init \
--external-etcd-endpoints="http://NODE_1:2379" \
--external-etcd-endpoints="http://NODE_2:2379"
```
#### External, two nodes, TLS enabled with self-signed certificate

Make sure `/etc/ssl/certs/etcd/ca.pem` file exists on the pod and its contents have the CA certificate.

```
kubeadm init \
--external-etcd-endpoints="https://NODE_1:2379" \
--external-etcd-endpoints="https://NODE_2:2379" \
--external-etcd-cafile=/etc/ssl/certs/etcd/ca.pem
```
#### External, two nodes, TLS enabled with self-signed certificate, client authentication enabled

Make sure:
- `/etc/ssl/certs/etcd/ca.pem` file exists on the pod and its contents have the CA certificate.
- `/etc/ssl/certs/etcd/client.pem` file exists on the pod and contents have the client certificate.
- `/etc/ssl/certs/etcd/client-key.pem` file exists on the pod and contents have the client key.

```
kubeadm init \
--external-etcd-endpoints="https://NODE_1:2379" \
--external-etcd-endpoints="https://NODE_2:2379" \
--external-etcd-cafile=/etc/ssl/certs/etcd/ca.pem\
--external-etcd-certfile=/etc/ssl/certs/etcd/client.pem \
--external-etcd-keyfile=/etc/ssl/certs/etcd/client-key.pem
```
