### PR TITLE
Add option for node CIDR allocation to kubeadm

### DIFF
--- a/cmd/kubeadm/app/api/types.go
+++ b/cmd/kubeadm/app/api/types.go
@@ -45,6 +45,9 @@ type InitFlags struct {
 		CIDR      net.IPNet
 		DNSDomain string
 	}
+	PodNetwork struct {
+		CIDR net.IPNet
+	}
 	CloudProvider string
 	Schedulable   bool
 }

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -65,22 +65,27 @@ func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 		&s.InitFlags.API.ExternalDNSNames, "api-external-dns-names", []string{},
 		`(optional) The DNS names to advertise, in case you have configured them yourself.`,
 	)
-
 	cmd.PersistentFlags().IPNetVar(
 		&s.InitFlags.Services.CIDR, "service-cidr", *kubeadmapi.DefaultServicesCIDR,
-		`(optional) use alternative range of IP address for service VIPs, e.g. "10.16.0.0/12"`,
+		`(optional) Use alterantive range of IP address for service VIPs, defaults to `+
+			kubeadmapi.DefaultServicesCIDRString,
+	)
+	cmd.PersistentFlags().IPNetVar(
+		&s.InitFlags.PodNetwork.CIDR, "cluster-cidr", net.IPNet{},
+		`(optional) Use alternative range of IP addresses for the pod overlay network VIPs, e.g. 10.3.0.0/16.`+
+			`If set, the control plane will automatically attempt to allocate Pod network CIDRs for every node.`,
 	)
 	cmd.PersistentFlags().StringVar(
 		&s.InitFlags.Services.DNSDomain, "service-dns-domain", kubeadmapi.DefaultServiceDNSDomain,
-		`(optional) use alternative domain for services, e.g. "myorg.internal"`,
+		`(optional) Use alternative domain for services, e.g. "myorg.internal"`,
 	)
 	cmd.PersistentFlags().StringVar(
 		&s.InitFlags.CloudProvider, "cloud-provider", "",
-		`(optional) enable a specific cloud provider features (external load-balancers, storage, etc), e.g. "gce"`,
+		`(optional) Enable a specific cloud provider features (external load-balancers, storage, etc), e.g. "gce"`,
 	)
 	cmd.PersistentFlags().BoolVar(
 		&s.InitFlags.Schedulable, "schedule-workload", false,
-		`(optional) allow to schedule workload to the node`,
+		`(optional) Allow to schedule workload to the node`,
 	)
 
 	return cmd

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -219,7 +219,6 @@ func getComponentCommand(component string, s *kubeadmapi.KubeadmConfig) (command
 			"--cluster-signing-cert-file=" + pkiDir + "/ca.pem",
 			"--cluster-signing-key-file=" + pkiDir + "/ca-key.pem",
 			"--insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap",
-			"--cluster-cidr=" + s.InitFlags.Services.CIDR.String(),
 		},
 		scheduler: []string{
 			// TODO: consider adding --address=127.0.0.1 in order to not expose the scheduler port to the rest of the world
@@ -238,12 +237,25 @@ func getComponentCommand(component string, s *kubeadmapi.KubeadmConfig) (command
 	command = append(command, s.EnvParams["component_loglevel"])
 	command = append(command, baseFlags[component]...)
 
-	if component == controllerManager && s.InitFlags.CloudProvider != "" {
-		command = append(command, "--cloud-provider="+s.InitFlags.CloudProvider)
+	if component == controllerManager {
+		if s.InitFlags.CloudProvider != "" {
+			command = append(command, "--cloud-provider="+s.InitFlags.CloudProvider)
+
+			// Only append the --cloud-config option if there's a such file
+			if _, err := os.Stat(DefaultCloudConfigPath); err == nil {
+				command = append(command, "--cloud-config="+DefaultCloudConfigPath)
+			}
+		}
 
 		// Only append the --cloud-config option if there's a such file
 		if _, err := os.Stat(DefaultCloudConfigPath); err == nil {
 			command = append(command, "--cloud-config="+DefaultCloudConfigPath)
+		}
+
+		if s.InitFlags.PodNetwork.CIDR.IP != nil {
+			// Let the controller-manager allocate Node CIDRs for the Pod overlay network.
+			// Each node will get a subspace of the address CIDR provided with --cluster-cidr.
+			command = append(command, "--allocate-node-cidrs=true", "--cluster-cidr="+s.InitFlags.PodNetwork.CIDR.String())
 		}
 	}
 


### PR DESCRIPTION
@errordeveloper Hi, I've been following the sig-cluster-lifecycle for a while, and I am interested in what you guys are doing :) I like it a lot.

I've been testing out `kubeadm` for the last couple of days and I managed to provision an operational cluster on 2 Ubuntu Xenial nodes. However, I had to introduce the following changes in the code:
- For some reason the Services CIDR was passed as Cluster CIDR to the controller-manager. Cluster CIDR is there for the pod network, however, so I don't think that was OK. A lot of the current provisioning projects (e.g. bootkube, kube-deploy/docker-multinode) use flannel as an overlay, and without my changes  flannel won't work
- There was a small bug in the `manual bootstrap`, when the bearer token is referenced in the code.

If you need help on any open topics just ping me, I'd be glad to contribute :) 

@kenan435 @cheld
