### PR TITLE
Fix package / struct naming after core refactoring.

### DIFF
--- a/cmd/kubeadm/app/master/addons.go
+++ b/cmd/kubeadm/app/master/addons.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	ipallocator "k8s.io/kubernetes/pkg/registry/service/ipallocator"
+	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 

--- a/cmd/kubeadm/app/master/pki.go
+++ b/cmd/kubeadm/app/master/pki.go
@@ -23,7 +23,7 @@ import (
 	"path"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/api"
-	ipallocator "k8s.io/kubernetes/pkg/registry/service/ipallocator"
+	ipallocator "k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
@@ -33,7 +33,7 @@ func newCertificateAuthority() (*rsa.PrivateKey, *x509.Certificate, error) {
 		return nil, nil, fmt.Errorf("unable to create private key [%s]", err)
 	}
 
-	config := certutil.CertConfig{
+	config := certutil.Config{
 		CommonName: "kubernetes",
 	}
 
@@ -66,7 +66,7 @@ func newServerKeyAndCert(s *kubeadmapi.KubeadmConfig, caCert *x509.Certificate, 
 	altNames.IPs = append(altNames.IPs, internalAPIServerVirtualIP)
 	altNames.DNSNames = append(altNames.DNSNames, internalAPIServerFQDN...)
 
-	config := certutil.CertConfig{
+	config := certutil.Config{
 		CommonName: "kube-apiserver",
 		AltNames:   altNames,
 	}
@@ -84,7 +84,7 @@ func newClientKeyAndCert(caCert *x509.Certificate, caKey *rsa.PrivateKey) (*rsa.
 		return nil, nil, fmt.Errorf("unable to create private key [%s]", err)
 	}
 
-	config := certutil.CertConfig{
+	config := certutil.Config{
 		CommonName: "kubernetes-admin",
 	}
 	cert, err := certutil.NewSignedCert(config, key, caCert, caKey)


### PR DESCRIPTION
@errordeveloper seems like there was some refactoring in `master` of k8s core. Now `kubeadm` should compile.

You can merge this or update the PR with your own commit, I didn't want to clutter the review with insignificant things.
