### PR TITLE
Add kubeadm flags to known-flags.txt

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -9,6 +9,8 @@ all-namespaces
 allocate-node-cidrs
 allow-privileged
 allowed-not-ready-nodes
+api-advertise-addresses
+api-external-dns-names
 api-burst
 api-prefix
 api-rate
@@ -176,6 +178,10 @@ experimental-keystone-url
 experimental-nvidia-gpus
 experimental-prefix
 experimental-runtime-integration-type
+external-etcd-cafile
+external-etcd-certfile
+external-etcd-endpoints
+external-etcd-keyfile
 external-hostname
 external-ip
 extra-peer-dirs
@@ -385,6 +391,7 @@ pod-cidr
 pod-eviction-timeout
 pod-infra-container-image
 pod-manifest-path
+pod-network-cidr
 pod-running
 pods-per-core
 policy-config-file
@@ -448,6 +455,7 @@ runtime-config
 runtime-integration-type
 runtime-request-timeout
 save-config
+schedule-workload
 scheduler-config
 scheduler-name
 schema-cache-dir
@@ -462,6 +470,8 @@ service-account-lookup
 service-account-private-key-file
 service-address
 service-cluster-ip-range
+service-cidr
+service-dns-domain
 service-generator
 service-node-port-range
 service-node-ports


### PR DESCRIPTION
Fix [CI failure](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/33262/kubernetes-pull-verify-all/15368/).

```
Found flags in golang files not in the list of known flags. Please add these to hack/verify-flags/known-flags.txt
api-advertise-addresses
api-external-dns-names
external-etcd-cafile
external-etcd-certfile
external-etcd-endpoints
external-etcd-keyfile
pod-network-cidr
schedule-workload
service-cidr
service-dns-domain
[0;31mFAILED[0m   hack/make-rules/../../hack/verify-flags-underscore.py   3s
Makefile:99: recipe for target 'verify' failed
make: *** [verify] Error 1

```
