### PR TITLE
Rename flag `--schedule-workload` to `--schedule-pods-here` for kubeadm init

### DIFF
--- a/cmd/kubeadm/README.md
+++ b/cmd/kubeadm/README.md
@@ -29,10 +29,10 @@ default behaviour. The flags used for said purpose are described below.
 
   By default, `kubeadm` sets `cluster.local` as the cluster DNS domain. If you would like to set a different one, use `--service-dns-domain`.
 
-- `--schedule-workload=<bool>` (default: "false")
+- `--schedule-pods-here=<bool>` (default: "false")
 
   By default, `kubeadm` sets the master node kubelet as non-schedulable for workloads. This means the master node won't run your pods. If you want to change that,
-  use `--schedule-workload=true`.
+  use `--schedule-pods-here=true`.
 
 - `--cloud-provider=<cloud provider>`
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -83,7 +83,7 @@ func NewCmdInit(out io.Writer, s *kubeadmapi.KubeadmConfig) *cobra.Command {
 		`(optional) Enable a specific cloud provider features (external load-balancers, storage, etc), e.g. "gce"`,
 	)
 	cmd.PersistentFlags().BoolVar(
-		&s.InitFlags.Schedulable, "schedule-workload", false,
+		&s.InitFlags.Schedulable, "schedule-pods-here", false,
 		`(optional) Allow to schedule workload to the node`,
 	)
 

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -455,7 +455,7 @@ runtime-config
 runtime-integration-type
 runtime-request-timeout
 save-config
-schedule-workload
+schedule-pods-here
 scheduler-config
 scheduler-name
 schema-cache-dir


### PR DESCRIPTION
As it [was discussed in comments](https://github.com/kubernetes/kubernetes/pull/33262#discussion_r80002476), replacing `--schedule-workload` with `--schedule-pods-here` for `kubeadm init` command.
