### PR TITLE
Fix boostrap token encoding bug during master init

### DIFF
--- a/cmd/kubeadm/app/master/discovery.go
+++ b/cmd/kubeadm/app/master/discovery.go
@@ -18,7 +18,6 @@ package master
 
 import (
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -52,7 +51,7 @@ func encodeKubeDiscoverySecretData(s *kubeadmapi.KubeadmConfig, caCert *x509.Cer
 		endpointList = append(endpointList, fmt.Sprintf("https://%s:443", addr.String()))
 	}
 
-	tokenMap[s.Secrets.TokenID] = hex.EncodeToString(s.Secrets.Token)
+	tokenMap[s.Secrets.TokenID] = s.Secrets.BearerToken
 
 	data["endpoint-list.json"], _ = json.Marshal(endpointList)
 	data["token-map.json"], _ = json.Marshal(tokenMap)


### PR DESCRIPTION
@errordeveloper @dgoodwin

Hey guys, found a nifty little bug. It happens when you provide a token to the `init` command on master instead of letting `kubeadm` generate one. Then the master is bootstrapped fine, but `kubeadm join` complains that the signature is not valid.

Reason why that happens: encoding of the token string in the secret of `kube-discovery`. 
#### Generated token case

Right [here](https://github.com/errordeveloper/kubernetes/blob/kubeadm/cmd/kubeadm/app/util/tokens.go#L42) 8 generated bytes are interpreted as a HEX number, resulting into a 16-symbol HEX string. The 16-char string is then saved in `s.Secrets.BearerToken`, the 8 bytes are saved in `s.Secrets.Token`. The `kube-discovery` token map is then created in the line I've changed in this PR, using `hex.EncodeToString(s.Secrets.Token)` which again gives this 16-char HEX string. This string is sent to `kube-discovery`.

On `kube-discovery`'s side, the 16-char HEX string is then interpreted _DIRECTLY_ [here](https://github.com/kubernetes/kubernetes/pull/32203/files#diff-56a1010acbabbd4064864f2499b8d44bR166), (`[]byte` conversion), resulting into a 16 byte shared secret. The `kubeadm join` command then parses the passed token [here](https://github.com/errordeveloper/kubernetes/blob/kubeadm/cmd/kubeadm/app/util/tokens.go#L80) and [here](https://github.com/errordeveloper/kubernetes/blob/kubeadm/cmd/kubeadm/app/util/tokens.go#L80), again parsing _DIRECTLY_ and obtaining the same 16 byte long shared secret. In this case the bootstrap works.
#### User-passed init token case

Here's where the failure happens. In this case a token is not generated, so the program flow goes through [UseGivenTokenIfValid](https://github.com/errordeveloper/kubernetes/blob/kubeadm/cmd/kubeadm/app/util/tokens.go#L63) - the same method used on `node join`. BUT this time the 16-char long string is interpreted _DIRECTLY_ (with `[]byte` conversion) resulting into 16 bytes, and [here](https://github.com/errordeveloper/kubernetes/blob/kubeadm/cmd/kubeadm/app/util/tokens.go#L83) `s.Secrets.Token` is set to those 16 bytes. Now the original line I've changed below is wrong, as it tries to `hex.EncodeToString` something that was decoded directly, and not into HEX. The result is a failure during bootstrap of the node, as the token in the secret is not the same as the string it was meant to be.

What do you think? Hope you can follow my line of thought... I'm not sure how long the shared secret should be, 8 byte or 16 byte. Right now it's 16 byte when generated. If it should be 8, then we should use `hex.DecodeString()` everywhere (also in `kube-discovery`) and I can adjust this PR to match this. If 16 byte shared secret is OK, then my change in this PR should be enough.
